### PR TITLE
Fix building with gcc 10 and -fno-common

### DIFF
--- a/radio.h
+++ b/radio.h
@@ -137,11 +137,11 @@ extern radio_device_t radio_rt84;       // Baofeng DM-1701, Retevis RT84
 extern unsigned char radio_mem[];
 
 //
-// File descriptor of serial port with programming cable attached.
+// File descriptor of serial port with programming cable attached, currently unused.
 //
-int radio_port;
+extern int radio_port;
 
 //
 // Read/write progress counter.
 //
-int radio_progress;
+extern int radio_progress;

--- a/util.c
+++ b/util.c
@@ -44,6 +44,8 @@
 //
 #define NCTCSS  50
 
+int trace_flag = 0;
+
 static const int CTCSS_TONES [NCTCSS] = {
      670,  693,  719,  744,  770,  797,  825,  854,  885,  915,
      948,  974, 1000, 1035, 1072, 1109, 1148, 1188, 1230, 1273,

--- a/util.h
+++ b/util.h
@@ -35,7 +35,7 @@ extern const char *copyright;
 //
 // Trace data i/o via the serial port.
 //
-int trace_flag;
+extern int trace_flag;
 
 //
 // Print data in hex format.


### PR DESCRIPTION
Thus, `make` works without having to use `-fcommon` on Arch Linux, addresses #52 . I hope I got the intended use of those variables right.