### PR TITLE
Add support for cross compilation in the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CC             ?= gcc
+PKG_CONFIG     ?= pkg-config
 
 VERSION         = $(shell git describe --tags --abbrev=0)
 GITCOUNT        = $(shell git rev-list HEAD --count)
@@ -8,14 +9,14 @@ OBJS            = main.o util.o radio.o dfu-libusb.o uv380.o md380.o rd5r.o \
                   gd77.o hid.o serial.o d868uv.o dm1801.o
 CFLAGS         ?= -g -O -Wall -Werror 
 CFLAGS         += -DVERSION='"$(VERSION).$(GITCOUNT)"' \
-                  $(shell pkg-config --cflags libusb-1.0)
+                  $(shell $(PKG_CONFIG) --cflags libusb-1.0)
 LDFLAGS        ?= -g
-LIBS            = $(shell pkg-config --libs --static libusb-1.0)
+LIBS            = $(shell $(PKG_CONFIG) --libs --static libusb-1.0)
 
 #
 # Make sure pkg-config is installed.
 #
-ifeq ($(shell pkg-config --version),)
+ifeq ($(shell $(PKG_CONFIG) --version),)
     $(error Fatal error: pkg-config is not installed)
 endif
 


### PR DESCRIPTION
This patch was needed in Debian, but I don't see any reason why it couldn't be upstream directly. Other Linux distributions might need it too.

This patch was originally from Helmut Grohne: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=943749#5