### PR TITLE
fix: deprecated kIO*PortDefault on macos 12+

### DIFF
--- a/serial.c
+++ b/serial.c
@@ -50,6 +50,7 @@
 #endif
 
 #ifdef __APPLE__
+#   include <Availability.h>
 #   include <CoreFoundation/CoreFoundation.h>
 #   include <IOKit/usb/IOUSBLib.h>
 #   include <IOKit/serial/IOSerialKeys.h>
@@ -440,7 +441,20 @@ static char *find_path(int vid, int pid)
     }
 
     io_iterator_t devices = IO_OBJECT_NULL;
-    kern_return_t ret = IOServiceGetMatchingServices(kIOMasterPortDefault,
+
+    #ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+        // code only compiled when targeting Mac OS X and not iPhone
+        // note: we use of 101200 instead of __MAC_10_12
+        #if __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+            // code in here might run on pre-Monterey OS
+            mach_port_t defaultPort = kIOMasterPortDefault;
+        #else
+            // code here can assume Monterey or later
+            mach_port_t defaultPort = kIOMainPortDefault;
+        #endif
+    #endif
+
+    kern_return_t ret = IOServiceGetMatchingServices(defaultPort,
         dict, &devices);
     if (ret != KERN_SUCCESS) {
         printf("Cannot find matching IO services.\n");


### PR DESCRIPTION
The `kIOMasterPortDefault` is deprecated since macos 12.0, in favor of `kIOMainPortDefault`
Thus I followed the recommended C precompilation macros from Apple defined within [`Availability.h`](https://opensource.apple.com/source/xnu/xnu-2050.18.24/EXTERNAL_HEADERS/Availability.h.auto.html)

```
    It is also possible to use the *_VERSION_MIN_REQUIRED in source code to make one
    source base that can be compiled to target a range of OS versions.  It is best
    to not use the _MAC_* and __IPHONE_* macros for comparisons, but rather their values.
    That is because you might get compiled on an old OS that does not define a later
    OS version macro, and in the C preprocessor undefined values evaluate to zero
    in expresssions, which could cause the #if expression to evaluate in an unexpected
    way.
    
        #ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
            // code only compiled when targeting Mac OS X and not iPhone
            // note use of 1050 instead of __MAC_10_5
            #if __MAC_OS_X_VERSION_MIN_REQUIRED < 1050
                // code in here might run on pre-Leopard OS
            #else
                // code here can assume Leopard or later
            #endif
        #endif
```