### PR TITLE
Remove unused variable.

### DIFF
--- a/d868uv.c
+++ b/d868uv.c
@@ -2028,7 +2028,6 @@ static int parse_zones(int first_row, char *line)
 
     if (*chan_str != '-') {
         char *str   = chan_str;
-        int   nchan = 0;
         int   range = 0;
         int   last  = 0;
 
@@ -2054,7 +2053,6 @@ static int parse_zones(int first_row, char *line)
                         fprintf(stderr, "Zone %d: too many channels.\n", znum);
                         return 0;
                     }
-                    nchan++;
                 }
             } else {
                 // Add single channel.
@@ -2062,7 +2060,6 @@ static int parse_zones(int first_row, char *line)
                     fprintf(stderr, "Zone %d: too many channels.\n", znum);
                     return 0;
                 }
-                nchan++;
             }
 
             if (*eptr == 0)
@@ -2200,7 +2197,6 @@ static int parse_scanlist(int first_row, char *line)
 
     if (*chan_str != '-') {
         char *str   = chan_str;
-        int   nchan = 0;
         int   range = 0;
         int   last  = 0;
 
@@ -2226,7 +2222,6 @@ static int parse_scanlist(int first_row, char *line)
                         fprintf(stderr, "Scan list %d: too many channels.\n", snum);
                         return 0;
                     }
-                    nchan++;
                 }
             } else {
                 // Add single channel.
@@ -2234,7 +2229,6 @@ static int parse_scanlist(int first_row, char *line)
                     fprintf(stderr, "Scan list %d: too many channels.\n", snum);
                     return 0;
                 }
-                nchan++;
             }
 
             if (*eptr == 0)

--- a/dm1801.c
+++ b/dm1801.c
@@ -1805,7 +1805,6 @@ static int parse_zones(int first_row, char *line)
 
     if (*chan_str != '-') {
         char *str   = chan_str;
-        int   nchan = 0;
         int   range = 0;
         int   last  = 0;
 
@@ -1831,7 +1830,6 @@ static int parse_zones(int first_row, char *line)
                         fprintf(stderr, "Zone %d: too many channels.\n", znum);
                         return 0;
                     }
-                    nchan++;
                 }
             } else {
                 // Add single channel.
@@ -1839,7 +1837,6 @@ static int parse_zones(int first_row, char *line)
                     fprintf(stderr, "Zone %d: too many channels.\n", znum);
                     return 0;
                 }
-                nchan++;
             }
 
             if (*eptr == 0)
@@ -1930,7 +1927,6 @@ static int parse_scanlist(int first_row, char *line)
         scanlist_append(snum-1, 0);
     } else {
         char *str   = chan_str;
-        int   nchan = 0;
         int   range = 0;
         int   last  = 0;
 
@@ -1956,7 +1952,6 @@ static int parse_scanlist(int first_row, char *line)
                         fprintf(stderr, "Scan list %d: too many channels.\n", snum);
                         return 0;
                     }
-                    nchan++;
                 }
             } else {
                 // Add single channel.
@@ -1964,7 +1959,6 @@ static int parse_scanlist(int first_row, char *line)
                     fprintf(stderr, "Scan list %d: too many channels.\n", snum);
                     return 0;
                 }
-                nchan++;
             }
 
             if (*eptr == 0)

--- a/gd77.c
+++ b/gd77.c
@@ -1803,7 +1803,6 @@ static int parse_zones(int first_row, char *line)
 
     if (*chan_str != '-') {
         char *str   = chan_str;
-        int   nchan = 0;
         int   range = 0;
         int   last  = 0;
 
@@ -1829,7 +1828,6 @@ static int parse_zones(int first_row, char *line)
                         fprintf(stderr, "Zone %d: too many channels.\n", znum);
                         return 0;
                     }
-                    nchan++;
                 }
             } else {
                 // Add single channel.
@@ -1837,7 +1835,6 @@ static int parse_zones(int first_row, char *line)
                     fprintf(stderr, "Zone %d: too many channels.\n", znum);
                     return 0;
                 }
-                nchan++;
             }
 
             if (*eptr == 0)
@@ -1928,7 +1925,6 @@ static int parse_scanlist(int first_row, char *line)
         scanlist_append(snum-1, 0);
     } else {
         char *str   = chan_str;
-        int   nchan = 0;
         int   range = 0;
         int   last  = 0;
 
@@ -1954,7 +1950,6 @@ static int parse_scanlist(int first_row, char *line)
                         fprintf(stderr, "Scan list %d: too many channels.\n", snum);
                         return 0;
                     }
-                    nchan++;
                 }
             } else {
                 // Add single channel.
@@ -1962,7 +1957,6 @@ static int parse_scanlist(int first_row, char *line)
                     fprintf(stderr, "Scan list %d: too many channels.\n", snum);
                     return 0;
                 }
-                nchan++;
             }
 
             if (*eptr == 0)

--- a/md380.c
+++ b/md380.c
@@ -1699,7 +1699,6 @@ static int parse_zones(int first_row, char *line)
 
     if (*chan_str != '-') {
         char *str   = chan_str;
-        int   nchan = 0;
         int   range = 0;
         int   last  = 0;
 
@@ -1725,7 +1724,6 @@ static int parse_zones(int first_row, char *line)
                         fprintf(stderr, "Zone %d: too many channels.\n", znum);
                         return 0;
                     }
-                    nchan++;
                 }
             } else {
                 // Add single channel.
@@ -1733,7 +1731,6 @@ static int parse_zones(int first_row, char *line)
                     fprintf(stderr, "Zone %d: too many channels.\n", znum);
                     return 0;
                 }
-                nchan++;
             }
 
             if (*eptr == 0)
@@ -1816,7 +1813,6 @@ static int parse_scanlist(int first_row, char *line)
 
     if (*chan_str != '-') {
         char *str   = chan_str;
-        int   nchan = 0;
         int   range = 0;
         int   last  = 0;
 
@@ -1842,7 +1838,6 @@ static int parse_scanlist(int first_row, char *line)
                         fprintf(stderr, "Scan list %d: too many channels.\n", snum);
                         return 0;
                     }
-                    nchan++;
                 }
             } else {
                 // Add single channel.
@@ -1850,7 +1845,6 @@ static int parse_scanlist(int first_row, char *line)
                     fprintf(stderr, "Scan list %d: too many channels.\n", snum);
                     return 0;
                 }
-                nchan++;
             }
 
             if (*eptr == 0)

--- a/rd5r.c
+++ b/rd5r.c
@@ -1801,7 +1801,6 @@ static int parse_zones(int first_row, char *line)
 
     if (*chan_str != '-') {
         char *str   = chan_str;
-        int   nchan = 0;
         int   range = 0;
         int   last  = 0;
 
@@ -1827,7 +1826,6 @@ static int parse_zones(int first_row, char *line)
                         fprintf(stderr, "Zone %d: too many channels.\n", znum);
                         return 0;
                     }
-                    nchan++;
                 }
             } else {
                 // Add single channel.
@@ -1835,7 +1833,6 @@ static int parse_zones(int first_row, char *line)
                     fprintf(stderr, "Zone %d: too many channels.\n", znum);
                     return 0;
                 }
-                nchan++;
             }
 
             if (*eptr == 0)
@@ -1926,7 +1923,6 @@ static int parse_scanlist(int first_row, char *line)
         scanlist_append(snum-1, 0);
     } else {
         char *str   = chan_str;
-        int   nchan = 0;
         int   range = 0;
         int   last  = 0;
 
@@ -1952,7 +1948,6 @@ static int parse_scanlist(int first_row, char *line)
                         fprintf(stderr, "Scan list %d: too many channels.\n", snum);
                         return 0;
                     }
-                    nchan++;
                 }
             } else {
                 // Add single channel.
@@ -1960,7 +1955,6 @@ static int parse_scanlist(int first_row, char *line)
                     fprintf(stderr, "Scan list %d: too many channels.\n", snum);
                     return 0;
                 }
-                nchan++;
             }
 
             if (*eptr == 0)

--- a/uv380.c
+++ b/uv380.c
@@ -1796,7 +1796,6 @@ static int parse_zones(int first_row, char *line)
 
     if (*chan_str != '-') {
         char *str   = chan_str;
-        int   nchan = 0;
         int   range = 0;
         int   last  = 0;
 
@@ -1822,7 +1821,6 @@ static int parse_zones(int first_row, char *line)
                         fprintf(stderr, "Zone %d: too many channels.\n", znum);
                         return 0;
                     }
-                    nchan++;
                 }
             } else {
                 // Add single channel.
@@ -1830,7 +1828,6 @@ static int parse_zones(int first_row, char *line)
                     fprintf(stderr, "Zone %d: too many channels.\n", znum);
                     return 0;
                 }
-                nchan++;
             }
 
             if (*eptr == 0)
@@ -1913,7 +1910,6 @@ static int parse_scanlist(int first_row, char *line)
 
     if (*chan_str != '-') {
         char *str   = chan_str;
-        int   nchan = 0;
         int   range = 0;
         int   last  = 0;
 
@@ -1939,7 +1935,6 @@ static int parse_scanlist(int first_row, char *line)
                         fprintf(stderr, "Scan list %d: too many channels.\n", snum);
                         return 0;
                     }
-                    nchan++;
                 }
             } else {
                 // Add single channel.
@@ -1947,7 +1942,6 @@ static int parse_scanlist(int first_row, char *line)
                     fprintf(stderr, "Scan list %d: too many channels.\n", snum);
                     return 0;
                 }
-                nchan++;
             }
 
             if (*eptr == 0)


### PR DESCRIPTION
`nchan` was set and maintained but never used in the `parse_zones` and `parse_scanlist` functions for six radios, resulting in this error with clang 15.0.0 and zig 0.11.0:

```plain
dm1801.c:1808:15: error: variable 'nchan' set but not used [-Werror,-Wunused-but-set-variable]
        int   nchan = 0;
```