### PR TITLE
Proposed fix to issue #77 Build Fail on Fedora

### DIFF
--- a/radio.c
+++ b/radio.c
@@ -63,6 +63,37 @@ int radio_progress;                     // Read/write progress counter
 
 static radio_device_t *device;          // Device-dependent interface
 
+
+// strnstr() is a BSD function not found in many GNU/Linux distros
+#ifndef strnstr
+
+/*
+ * Find the first occurrence of find in s, where the search is limited to the
+ * first slen characters of s.
+ */
+char *
+strnstr(const char *s, const char *find, size_t slen)
+{
+	char c, sc;
+	size_t len;
+
+	if ((c = *find++) != '\0') {
+		len = strlen(find);
+		do {
+			do {
+				if (slen-- < 1 || (sc = *s++) == '\0')
+					return (NULL);
+			} while (sc != c);
+			if (len > slen)
+				return (NULL);
+		} while (strncmp(s, find, len) != 0);
+		s--;
+	}
+	return ((char *)s);
+}
+#endif
+
+
 //
 // Close the serial port.
 //


### PR DESCRIPTION
(https://github.com/OpenRTX/dmrconfig/issues/77)

Provides BSD strnstr() function if not defined by build environment's C library.