### PR TITLE
don't use strnstr(line,…,strlen(line))

### DIFF
--- a/radio.c
+++ b/radio.c
@@ -35,6 +35,7 @@
 #include "radio.h"
 #include "util.h"
 
+
 static struct {
     char *ident;
     radio_device_t *device;
@@ -291,9 +292,9 @@ void radio_validate_config(const char *filename) {
 
   // First, find out which radio it is.
   while (fgets(line, sizeof(line), conf)) {
-    if (strnstr(line, "Radio:", strlen(line))) {
+    if (strstr(line, "Radio:")) {
       for (i = 0; radio_tab[i].ident; i++) {
-        if (strnstr(line, radio_tab[i].ident, strlen(line))) goto found;
+        if (strstr(line, radio_tab[i].ident)) goto found;
       }
     }
   }


### PR DESCRIPTION
That does nothing: strnstr only makes code any more secure than strstr if the length of the string to look through is known. If you have to use strlen, you might as well just use strstr, which does the same.

but unlike strnstr, strstr *IS* POSIX and not BSD-only / libbsd.

This broke buildability on a modern GCC system.

This PR thus restores the possibilty to build the software on Linux.
